### PR TITLE
Merging with PR #1184 of goulvenb

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
 
       - name: Build and push Docker image (multi-arch)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/README.md
+++ b/README.md
@@ -153,10 +153,13 @@ print(result.text_content)
 
 ### Docker
 
+We recommend you to use a specific tag, just as follow :
+
 ```sh
-docker build -t markitdown:latest .
-docker run --rm -i markitdown:latest < ~/your-file.pdf > output.md
+docker run --rm -i ghcr.io/microsoft/markitdown:v0.1.2 < ~/your-file.pdf > output.md
 ```
+
+It is nevertheless possible to use the `latest` or `main` tag.
 
 ## Contributing
 


### PR DESCRIPTION
From what i see, i believe we should implement the following :
- [https://github.com/microsoft/markitdown/pull/1184](https://github.com/microsoft/markitdown/pull/1184) : We create a container on tag creation
  - This way, we'll have access to `ghcr.io/microsoft/markitdown:v1.0.0`, `ghcr.io/microsoft/markitdown:v2.0.0`, ... Instead of just `ghcr.io/microsoft/markitdown:main`
- [https://github.com/microsoft/markitdown/pull/1184](https://github.com/microsoft/markitdown/pull/1184) : Use the 6th version of docker/build-push-action
  - I don't see why v5 should be used instead of v6 ? \
Also, the [most recent `docker/build-push-action`](https://github.com/docker/build-push-action/blob/88844b95d8cbbb41035fa9c94e5967a33b92db78/README.md?plain=1#L53-L81)'s README tell us that version compatibility with the other actions is not an issue

Also, i've updated the `README.md` file to use the newly provided docker images.